### PR TITLE
fix: resolve 3 console errors in preview, file system, and mock provider

### DIFF
--- a/src/components/preview/PreviewFrame.tsx
+++ b/src/components/preview/PreviewFrame.tsx
@@ -13,17 +13,12 @@ export function PreviewFrame() {
   const { getAllFiles, refreshTrigger } = useFileSystem();
   const [error, setError] = useState<string | null>(null);
   const [entryPoint, setEntryPoint] = useState<string>("/App.jsx");
-  const [isFirstLoad, setIsFirstLoad] = useState(true);
+  const isFirstLoadRef = useRef(true);
 
   useEffect(() => {
     const updatePreview = () => {
       try {
         const files = getAllFiles();
-
-        // Clear error first when we have files
-        if (files.size > 0 && error) {
-          setError(null);
-        }
 
         // Find the entry point - look for App.jsx, App.tsx, index.jsx, or index.tsx
         let foundEntryPoint = entryPoint;
@@ -54,7 +49,7 @@ export function PreviewFrame() {
         }
 
         if (files.size === 0) {
-          if (isFirstLoad) {
+          if (isFirstLoadRef.current) {
             setError("firstLoad");
           } else {
             setError("No files to preview");
@@ -63,9 +58,7 @@ export function PreviewFrame() {
         }
 
         // We have files, so it's no longer the first load
-        if (isFirstLoad) {
-          setIsFirstLoad(false);
-        }
+        isFirstLoadRef.current = false;
 
         if (!foundEntryPoint || !files.has(foundEntryPoint)) {
           setError(
@@ -96,7 +89,7 @@ export function PreviewFrame() {
     };
 
     updatePreview();
-  }, [refreshTrigger, getAllFiles, entryPoint, error, isFirstLoad]);
+  }, [refreshTrigger, getAllFiles, entryPoint]);
 
   if (error) {
     if (error === "firstLoad") {

--- a/src/lib/contexts/file-system-context.tsx
+++ b/src/lib/contexts/file-system-context.tsx
@@ -153,10 +153,7 @@ export function FileSystemProvider({
         switch (command) {
           case "create":
             if (path && file_text !== undefined) {
-              const result = fileSystem.createFileWithParents(path, file_text);
-              if (!result.startsWith("Error:")) {
-                createFile(path, file_text);
-              }
+              createFile(path, file_text);
             }
             break;
 

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -5,7 +5,7 @@ import {
   LanguageModelV1Message,
 } from "@ai-sdk/provider";
 
-const MODEL = "claude-haiku-4-5";
+const MODEL = "claude-haiku-4-5-20251001";
 
 export class MockLanguageModel implements LanguageModelV1 {
   readonly specificationVersion = "v1" as const;
@@ -320,17 +320,11 @@ export default Card;`;
 const Counter = () => {
   const [count, setCount] = useState(0);
 
-  const increment = () => {
-    setCount(count + 1);
-  };
+  const increment = () => setCount(count + 1);
 
-  const decrement = () => {
-    setCount(count - 1);
-  };
+  const decrement = () => setCount(count - 1);
 
-  const reset = () => {
-    setCount(0);
-  };
+  const reset = () => setCount(0);
 
   return (
     <div className="flex flex-col items-center p-6 bg-white rounded-lg shadow-md">


### PR DESCRIPTION
Fixes #3

- **PreviewFrame**: Convert `isFirstLoad` to `useRef` and remove `error`/`isFirstLoad` from `useEffect` deps to prevent extra re-runs and preview flicker
- **FileSystemContext**: Remove redundant `createFileWithParents` call in `handleToolCall` create case
- **provider**: Fix wrong model ID and mock Counter str_replace mismatch

Generated with [Claude Code](https://claude.ai/code)